### PR TITLE
extract: Add a performant indexOf escape

### DIFF
--- a/index.js
+++ b/index.js
@@ -44,6 +44,9 @@ function cssExtract (bundle, opts) {
 // extract css from chunks
 // obj -> str
 function extract (chunk) {
+  // Do a performant check before building the ast
+  if (String(chunk.source).indexOf('insert-css') === -1) return ''
+
   const css = []
   const ast = falafel(chunk.source, { ecmaVersion: 6 }, walk)
   chunk.source = ast.toString()


### PR DESCRIPTION
When browserify is compiling hundreds of files, this gives a noticeable performance boost.

If you need a benchmark before merging this, I can make one.
