### PR TITLE
Skip non-matching insert-css statements

### DIFF
--- a/index.js
+++ b/index.js
@@ -54,6 +54,8 @@ function extract (chunk) {
     if (!node.arguments) return
     if (!node.arguments[0]) return
     if (node.arguments[0].value !== 'insert-css') return
+    if (!node.parent.arguments || !node.parent.arguments[0]) return
+
     css.push(node.parent.arguments[0].value)
     node.parent.update('0')
   }

--- a/test/index.js
+++ b/test/index.js
@@ -29,4 +29,25 @@ test('css-extract', function (t) {
       })
     }
   })
+
+  t.test('should leave non-matching insert-css statements inline', function (t) {
+    t.plan(4)
+
+    browserify(path.join(__dirname, 'manual-insert-source.js'))
+      .plugin(cssExtract, { out: readCss })
+      .bundle(readJs)
+
+    function readCss () {
+      return bl(function (err, data) {
+        t.ifError(err, 'no error')
+        t.equal(String(data), '', 'no css extracted')
+      })
+    }
+
+    function readJs (err, data) {
+      t.ifError(err, 'no error')
+      const source = fs.readFileSync(path.join(__dirname, 'manual-insert-source.js'), 'utf8')
+      t.ok(String(data).indexOf(String(source)) !== -1, 'source is still in built bundle')
+    }
+  })
 })

--- a/test/manual-insert-source.js
+++ b/test/manual-insert-source.js
@@ -1,0 +1,3 @@
+var insertCss = require('insert-css')
+
+insertCss('.foo{color: purple}')


### PR DESCRIPTION
This allows people to still use `require('insert-css')` in their code.
If it doesn't match the expected format, it just won't be extracted from the javascript bundle.

Before, non-matching `insert-css` statements caused an error.
