### PR TITLE
Use static-module to extract css

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,8 +21,7 @@
   "license": "MIT",
   "dependencies": {
     "concat-stream": "^1.5.1",
-    "falafel": "^1.2.0",
-    "is-require": "0.0.1",
+    "static-module": "^1.3.0",
     "through2": "^2.0.1"
   },
   "devDependencies": {

--- a/test/expected-static.css
+++ b/test/expected-static.css
@@ -1,0 +1,1 @@
+.foo {background: green}

--- a/test/source-dynamic.js
+++ b/test/source-dynamic.js
@@ -1,0 +1,5 @@
+insert('.foo {}')
+
+function insert (foo) {
+  require('insert-css')(foo)
+}

--- a/test/source-static.js
+++ b/test/source-static.js
@@ -1,0 +1,3 @@
+var insertCss = require('insert-css')
+
+insertCss('.foo {background: green}')


### PR DESCRIPTION
As discussed in #3.

You'll notice I didn't use a normal `bundle.transform` here. 

I did that because we need to guarantee that extract-css runs last, after all css and javascript has been compiled. Transforms added through plugins are actually run first.
