### PR TITLE
replace static `insert-css` calls with `null`

### DIFF
--- a/index.js
+++ b/index.js
@@ -40,6 +40,7 @@ function cssExtract (bundle, opts) {
       var sm = staticModule({
         'insert-css': function (src) {
           writeStream.write(String(src))
+          return from2('null')
         }
       })
 

--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
     "through2": "^2.0.1"
   },
   "devDependencies": {
-    "bl": "^1.1.2",
     "browserify": "^13.0.0",
     "dependency-check": "^2.5.1",
     "insert-css": "^0.2.0",


### PR DESCRIPTION
apparently they were being left as is?

motivation is to fix https://github.com/stackcss/sheetify/issues/77, as in that case we're already using `css-extract` but the `insert-css` calls remain.
