### PR TITLE
Run in 'label' phase instead of 'debug' phase

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,8 +27,8 @@ function cssExtract (bundle, opts) {
       ? outFile()
       : bl(writeComplete)
 
-    // run before the "debug" step in browserify pipeline
-    bundle.pipeline.get('debug').unshift(extractStream)
+    // run before the "label" step in browserify pipeline
+    bundle.pipeline.get('label').unshift(extractStream)
 
     function write (chunk, enc, cb) {
       // Performance boost: don't do ast parsing unless we know it's needed


### PR DESCRIPTION
This makes css-extract run before bundle-collapser. 

bundle-collapser will change `require('insert-css')` to a number, eg `require(1)`, which will break css-extract. So we must run before bundle-collapser.

Closes #5
