### PR TITLE
Add newlines between chunks of css

### DIFF
--- a/index.js
+++ b/index.js
@@ -39,7 +39,7 @@ function cssExtract (bundle, opts) {
       var source = from2(chunk.source)
       var sm = staticModule({
         'insert-css': function (src) {
-          writeStream.write(String(src) + '\n\n')
+          writeStream.write(String(src) + '\n')
           return from2('null')
         }
       })

--- a/index.js
+++ b/index.js
@@ -39,7 +39,7 @@ function cssExtract (bundle, opts) {
       var source = from2(chunk.source)
       var sm = staticModule({
         'insert-css': function (src) {
-          writeStream.write(String(src))
+          writeStream.write(String(src) + '\n\n')
           return from2('null')
         }
       })

--- a/test/index.js
+++ b/test/index.js
@@ -25,7 +25,7 @@ test('css-extract', function (t) {
       return bl(function (err, data) {
         t.ifError(err, 'no error')
         const exPath = path.join(__dirname, './expected.css')
-        const expected = fs.readFileSync(exPath, 'utf8').trim()
+        const expected = fs.readFileSync(exPath, 'utf8').trim() + '\n'
         t.equal(String(data), expected, 'extracted all the CSS')
       })
     }
@@ -65,7 +65,7 @@ test('css-extract', function (t) {
       return bl(function (err, data) {
         t.ifError(err, 'no error')
         const exPath = path.join(__dirname, './expected-static.css')
-        const expected = fs.readFileSync(exPath, 'utf8').trim()
+        const expected = fs.readFileSync(exPath, 'utf8').trim() + '\n'
         t.equal(String(data), expected, 'extracted all the CSS')
       })
     }


### PR DESCRIPTION
Right now, the different chunks of css overlap which isn't what we are trying to do at this step (the idea is that you can minify at a later point in the build step).  This adds some newlines between chunks of found css so that they don't slowly pule up on top of each other.
