### PR TITLE
Source maps :sparkles:

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@ const staticModule = require('static-module')
 const from2 = require('from2-string')
 const through = require('through2')
 const assert = require('assert')
+const d = require('defined')
 const bl = require('bl')
 const fs = require('fs')
 
@@ -13,6 +14,7 @@ function cssExtract (bundle, opts) {
   opts = opts || {}
 
   var outFile = opts.out || opts.o || 'bundle.css'
+  var sourceMap = d(opts.sourceMap, bundle && bundle._options && bundle._options.debug, false)
 
   assert.equal(typeof bundle, 'object', 'bundle should be an object')
   assert.equal(typeof opts, 'object', 'opts should be an object')
@@ -46,7 +48,7 @@ function cssExtract (bundle, opts) {
           writeStream.write(String(src) + '\n')
           return from2('null')
         }
-      })
+      }, { sourceMap: sourceMap })
 
       source.pipe(sm).pipe(bl(complete))
 

--- a/package.json
+++ b/package.json
@@ -21,8 +21,9 @@
   "license": "MIT",
   "dependencies": {
     "bl": "^1.1.2",
+    "defined": "^1.0.0",
     "from2-string": "^1.1.0",
-    "static-module": "^1.3.0",
+    "static-module": "^2.2.0",
     "through2": "^2.0.1"
   },
   "devDependencies": {


### PR DESCRIPTION
Set `opts.sourceMap` on the plugin or `opts.debug` in the browserify constructor to get source maps!